### PR TITLE
Add a treesitter text object that captures the current node

### DIFF
--- a/lua/custom/plugins/treesitter.lua
+++ b/lua/custom/plugins/treesitter.lua
@@ -109,6 +109,8 @@ return {
               ['r='] = '@assignment.rhs',
               ['a,'] = '@parameter.outer',
               ['i,'] = '@parameter.inner',
+              ['an'] = '@node.outer', -- New keymap for capturing the current node
+              ['in'] = '@node.inner', -- New keymap for capturing the current node
             },
             include_surrounding_whitespace = false,
           },


### PR DESCRIPTION
Add a treesitter text object to capture the current node.

* Add new keymaps `an` and `in` for capturing the current node in the `textobjects` configuration in `lua/custom/plugins/treesitter.lua`
* Update the `keymaps` section to include the new keymaps for capturing the current node
* Ensure the new text object is properly integrated with the existing treesitter configuration

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DaanHoogendoorn/config.nvim?shareId=0a447659-66e7-4e1c-8d71-96fec72eb67e).